### PR TITLE
[qemu-x86] Network arguments in the qemu command and network interfaces setup/reset script 

### DIFF
--- a/arch/qemu-x86.sh
+++ b/arch/qemu-x86.sh
@@ -112,8 +112,8 @@ function check_network
 		echo "Network TAP interface and bridge are setup"
 		exit 1
 	else
-		echo "You should setup a TAP interface and a bridge : \n
-			\t sudo ./nanvix-setup-network.sh on"
+		echo "You should setup a TAP interface and a bridge :
+	sudo ./nanvix-setup-network.sh on"
 	fi
 }
 

--- a/arch/qemu-x86.sh
+++ b/arch/qemu-x86.sh
@@ -107,13 +107,13 @@ function check_network
 	local foundtap=`grep "nanvix-tap" /proc/net/dev`
 	local foundbridge=`grep "nanvix-bridge" /proc/net/dev`
 
-	if  [ -n "$foundtap" and -n "$foundbridge" ]; 
+	if  [ -n "$foundtap" -a -n "$foundbridge" ] 
 	then
 		echo "Network TAP interface and bridge are setup"
-		exit 1
 	else
 		echo "You should setup a TAP interface and a bridge :
-	sudo ./nanvix-setup-network.sh on"
+	sudo bash ./nanvix-setup-network.sh on"
+		exit 1
 	fi
 }
 
@@ -144,7 +144,7 @@ function run
 			-kernel $bindir/$binary \
 			-m $MEMSIZE             \
 			-mem-prealloc			\
-			-netdev tap,id=t0,ifname=nanvix-tap,script=no,downscript=no \ 
+			-netdev tap,id=t0,ifname=nanvix-tap,script=no,downscript=no \
 			-device rtl8139,netdev=t0,id=nic0,mac=$mac
 	else
 		qemu-system-i386 -s         \

--- a/arch/qemu-x86.sh
+++ b/arch/qemu-x86.sh
@@ -99,6 +99,25 @@ function build
 }
 
 #
+# Very simple way of testing if the network interfaces exists. 
+# Testing if network interfaces are UP should be added
+#
+function check_network
+{
+	local foundtap=`grep "nanvix-tap" /proc/net/dev`
+	local foundbridge=`grep "nanvix-bridge" /proc/net/dev`
+
+	if  [ -n "$foundtap" and -n "$foundbridge" ]; 
+	then
+		echo "Network TAP interface and bridge are setup"
+		exit 1
+	else
+		echo "You should setup a TAP interface and a bridge : \n
+			\t sudo ./nanvix-setup-network.sh on"
+	fi
+}
+
+#
 # Runs a binary in the platform (simulator).
 #
 function run
@@ -111,6 +130,10 @@ function run
 	local mode=$6
 	local timeout=$7
 
+	local mac=52:55:00:d1:55:01
+
+	check_network
+
 	# Target configuration.
 	local MEMSIZE=128M # Memory Size
 		
@@ -120,12 +143,16 @@ function run
 			--display curses        \
 			-kernel $bindir/$binary \
 			-m $MEMSIZE             \
-			-mem-prealloc
+			-mem-prealloc			\
+			-netdev tap,id=t0,ifname=nanvix-tap,script=no,downscript=no \ 
+			-device rtl8139,netdev=t0,id=nic0,mac=$mac
 	else
 		qemu-system-i386 -s         \
 			--display curses        \
 			-kernel $bindir/$binary \
 			-m $MEMSIZE             \
-			-mem-prealloc
+			-mem-prealloc			\
+			-netdev tap,id=t0,ifname=nanvix-tap,script=no,downscript=no \
+			-device rtl8139,netdev=t0,id=nic0,mac=$mac
 	fi
 }

--- a/nanvix-setup-network.sh
+++ b/nanvix-setup-network.sh
@@ -1,0 +1,118 @@
+#
+# MIT License
+#
+# Copyright(c) 2011-2019 The Maintainers of Nanvix
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#
+
+#
+# NOTES:
+#   - This script setup (and reset) a Network TAP interface and a bridge for
+#  QEMU networking to work properly on qemu-x86.
+#   - You should run this script with superuser privileges.
+
+# Script Arguments
+COMMAND=$1    # Command, either on or off
+
+# Global Variables
+export SCRIPT_NAME=$0
+
+# Options
+# be careful changing those values, they are also hard coded in the qemu-x86.sh script
+# but I don't know the proper way to make them dependant.
+TAP_INTERFACE_NAME=nanvix-tap
+BRIDGE_INTERFACE_NAME=nanvix-bridge
+TAP_IP_ADRESS=192.168.66.66/24
+#==============================================================================
+# usage()
+#==============================================================================
+
+#
+# Prints script usage and exits.
+#
+function usage
+{
+	echo "$SCRIPT_NAME <command>
+        command: [on | off]"
+	exit 1
+}
+
+#==============================================================================
+# check_args()
+#==============================================================================
+
+#
+# Check script arguments.
+#
+function check_args
+{
+	# Missing image?
+	if [ -z $COMMAND ];
+	then
+		echo "$SCRIPT_NAME: missing command"
+		usage
+	fi
+
+	case $COMMAND in
+		"on" | "off")
+			;;
+		*)
+			echo "$SCRIPT_NAME: bad command [on | off]"
+			exit 1
+			;;
+	esac
+}
+
+#==============================================================================
+
+function on
+{
+    sudo ip link add $BRIDGE_INTERFACE_NAME type bridge
+    sudo ip tuntap add dev $TAP_INTERFACE_NAME mode tap
+    sudo ip link set $TAP_INTERFACE_NAME master $BRIDGE_INTERFACE_NAME
+    sudo ip link set dev $BRIDGE_INTERFACE_NAME up
+    sudo ip link set $TAP_INTERFACE_NAME up
+    sudo ip addr add dev $TAP_INTERFACE_NAME $TAP_IP_ADRESS
+
+    echo "Network interfaces successfully setup"
+}
+
+function off
+{
+    sudo ip link delete $TAP_INTERFACE_NAME
+    sudo ip link delete $BRIDGE_INTERFACE_NAME
+
+    echo "Network interfaces successfully reset"
+}
+
+check_args
+
+case $COMMAND in
+    "on")
+        on
+        ;;
+    "off")
+        off
+        ;;
+    *) # Should never happen
+        echo "$SCRIPT_NAME: bad command [on | off]"
+        exit 1
+        ;;
+esac
+

--- a/nanvix-setup-network.sh
+++ b/nanvix-setup-network.sh
@@ -81,6 +81,10 @@ function check_args
 
 #==============================================================================
 
+#
+# Setup a TAP interface and a bridge, link them together and 
+# give the TAP interface an IP adress
+#
 function on
 {
     sudo ip link add $BRIDGE_INTERFACE_NAME type bridge
@@ -91,8 +95,13 @@ function on
     sudo ip addr add dev $TAP_INTERFACE_NAME $TAP_IP_ADRESS
 
     echo "Network interfaces successfully setup"
+    echo "Remember that you can remove the interfaces :
+        sudo bash $SCRIPT_NAME off"
 }
 
+#
+# Remove the previously created interfaces
+#
 function off
 {
     sudo ip link delete $TAP_INTERFACE_NAME


### PR DESCRIPTION
The `nanvix-setup-network.sh` script should now be called by the user to setup network interfaces before launching qemu :
- `sudo bash ./nanvix-setup-network.sh on`
- launch qemu
- `sudo bash ./nanvix-setup-network.sh off`

Some values (`nanvix-tap` and `nanvix-bridge`) are hard coded in both file but I don't know the proper way of sharing them between files.

I add problems with git, I don't know why commits are duplicated...