### PR TITLE
Setup Network Username Fix

### DIFF
--- a/nanvix-setup-network.sh
+++ b/nanvix-setup-network.sh
@@ -64,6 +64,7 @@ function usage
 #==============================================================================
 # check_args()
 #==============================================================================
+USERNAME=$(logname 2>/dev/null || echo $SUDO_USER)
 
 #
 # Check script arguments.
@@ -144,13 +145,13 @@ function on_multiple
 		if [ ! -e /dev/net/$TAP_NAME ];
 		then
 			mknod /dev/net/$TAP_NAME c 10 200
-			chown $(id -u):$(id -g) /dev/net/$TAP_NAME
+			chown $USERNAME:$(id -gn $USERNAME) /dev/net/$TAP_NAME
 		fi
 
 		# Create tap interface.
 		if [ ! -e /sys/class/net/$TAP_NAME ];
 		then
-			tunctl -t $TAP_NAME -u $(id -un) > /dev/null
+			tunctl -t $TAP_NAME -u $USERNAME > /dev/null
 		fi
 
 		# Setup tap interface.


### PR DESCRIPTION
Description
---------------
In my latest PR, I've introduced a bug that seems to happen in Debian/Debian-like systems: `id` command returns the current user instead of the real user, so the script was chown-ning to the root instead of the logged user.

This PR fixes this by grabbing the username from the `logname` and `SUDO_USER` environment var and supplying this to the `id` command to get the expected user group.