### PR TITLE
Enhancement: Added Fedora prerequisites

### DIFF
--- a/nanvix-setup-prerequisites.sh
+++ b/nanvix-setup-prerequisites.sh
@@ -75,6 +75,20 @@ case "$DISTRO" in
 			texinfo        \
 			zlib
         ;;
+    *"fedora"*)
+        dnf install -y \
+			make		\
+			automake	\
+			autoconf	\
+			g++		\
+			bison		\
+			ncurses-devel	\
+			glib2-devel	\
+			pixman-devel	\
+			texinfo		\
+			flex		\
+			SDL2-devel	\
+        ;;
     *)
         echo "Warning: your distro is not officially supported"
 esac


### PR DESCRIPTION
Fedora is now supported when running nanvix-setup-prerequisites.sh.
Dependencies based on Fedora 32.