### PR TITLE
[Build] Consistent Toolchain Directory

### DIFF
--- a/arch/qemu-openrisc.sh
+++ b/arch/qemu-openrisc.sh
@@ -41,7 +41,7 @@ function setup_toolchain
 {
 	# Required variables.
 	local CURDIR=`pwd`
-	local WORKDIR=$CURDIR/toolchain/or1k
+	local WORKDIR=$SCRIPT_DIR/toolchain/or1k
 	local PREFIX=$WORKDIR
 	local TARGET=or1k-elf
 	local COMMIT=ccfd3f43e29a0b02249ffb3a256330a3717cca18

--- a/arch/qemu-riscv32.sh
+++ b/arch/qemu-riscv32.sh
@@ -41,7 +41,7 @@ function setup_toolchain
 {
 	# Required variables.
 	local CURDIR=`pwd`
-	local WORKDIR=$CURDIR/toolchain/riscv32
+	local WORKDIR=$SCRIPT_DIR/toolchain/riscv32
 	local PREFIX=$WORKDIR
 	local TARGET=riscv32-elf
 	local COMMIT=ab8b80604f02db4b00af24302bc9d20ebfcdd911

--- a/nanvix-setup-qemu.sh
+++ b/nanvix-setup-qemu.sh
@@ -23,8 +23,8 @@
 #
 
 # Build and install variables.
-export CURDIR=`pwd`
-export WORKDIR=$CURDIR/toolchain/qemu
+export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+export WORKDIR=$SCRIPT_DIR/toolchain/qemu
 export PREFIX=$WORKDIR
 
 # QEMU Version


### PR DESCRIPTION
# Description
If you executed the script to install the toolchain for QEMU-x86, it would be installed under utils/toolchain no matter from where the script was executed. 
However the scripts that set up QEMU and other toolchains would install the toolchain in the directory the scripts were executed from. Together with unclear build instructions, that would cause the toolchains to be located under the rootdir and make contrib / all to fail.

Now, the scripts install the toolchain in the correct directory no matter from where they are executed. 

Closes #27 