### PR TITLE
[arch] Standard Method to Parse Output Files

### DIFF
--- a/arch/mppa256.sh
+++ b/arch/mppa256.sh
@@ -95,7 +95,7 @@ function build
 	$cmd
 }
 
-function parse
+function parse_outputs
 {
 	local outfile=$1
 	local failed='failed|FAILED|Failed'
@@ -103,12 +103,14 @@ function parse
 
 	while read -r line;
 	do
-		if [[ $line =~ $failed ]]; then
+		if [[ $line =~ $failed ]];
+		then
 			echo "Failed !"
 			return 255
 		fi
 
-		if [[ $line = *"IODDR0@0.0: RM 0: [hal] powering off"* ]]; then
+		if [[ $line = *"IODDR0@0.0: RM 0: [hal] powering off"* ]];
+		then
 			success='true'
 		fi
 	done < "$outfile"
@@ -174,7 +176,7 @@ function run
 				$execfile                        \
 			|& tee $OUTFILE
 
-			parse $OUTFILE
+			parse_outputs $OUTFILE
 		else
 			$K1_TOOLCHAIN_DIR/bin/k1-jtag-runner         \
 				--multibinary=$image                     \

--- a/arch/qemu-openrisc.sh
+++ b/arch/qemu-openrisc.sh
@@ -126,17 +126,60 @@ function build
 function parse_output
 {
 	local outfile=$1
+	local failed='failed|FAILED|Failed'
+	local success='false'
 
-	line=$(cat $outfile | tail -1)
-	if [[ "$line" = *"powering off"* ]] || [[ $line == *"halting"* ]];
+	while read -r line;
+	do
+		if [[ $line =~ $failed ]];
+		then
+			return 255
+		fi
+
+		if [[ "$line" = *"powering off"* ]] || [[ $line == *"halting"* ]];
+		then
+			success='true'
+		fi
+	done < "$outfile"
+
+	if [[ $success != true ]];
+	then
+		return 255
+	fi
+
+	return 0
+}
+
+#
+# Parses all execution outputs.
+#
+# $1 Output file.
+#
+function parse_outputs
+{
+	local base_outfile=$1
+	local ret=0
+
+	for outfile in $base_outfile-*;
+	do
+		parse_output $outfile
+		ret=$?
+
+		if [ $ret == 255 ];
+		then
+			break
+		fi
+	done
+
+	# Print result
+	if [ $ret == 0 ];
 	then
 		echo "Succeed !"
 	else
 		echo "Failed !"
-		return -1
 	fi
 
-	return 0
+	return $ret
 }
 
 #
@@ -228,7 +271,7 @@ function run
 		# Parse output.
 		wait
 
-		parse_output $OUTFILE-0
+		parse_outputs $OUTFILE
 		ret=$?
 
 	# Run/Debug

--- a/arch/unix64.sh
+++ b/arch/unix64.sh
@@ -98,6 +98,38 @@ function parse_output
 }
 
 #
+# Parses all execution outputs.
+#
+# $1 Output file.
+#
+function parse_outputs
+{
+	local base_outfile=$1
+	local ret=0
+
+	for outfile in $base_outfile-*;
+	do
+		parse_output $outfile
+		ret=$?
+
+		if [ $ret == 255 ];
+		then
+			break
+		fi
+	done
+
+	# Print result
+	if [ $ret == 0 ];
+	then
+		echo "Succeed !"
+	else
+		echo "Failed !"
+	fi
+
+	return $ret
+}
+
+#
 # Spawns binaries.
 #
 # $1 Binary directory.
@@ -169,16 +201,8 @@ function run
 		# Parse output.
 		wait
 
-		for outfile in $OUTFILE-*;
-		do
-			parse_output $outfile
-			ret=$?
-
-			if [ $ret == 255 ];
-			then
-				break
-			fi
-		done
+		parse_outputs $OUTFILE
+		ret=$?
 
 	# Run/Debug
 	else
@@ -190,14 +214,6 @@ function run
 	# House keeping.
 	rm -rf /dev/mqueue/*nanvix*
 	rm -rf /dev/shm/*nanvix*
-
-	# Print result
-	if [ $ret == 0 ];
-	then
-		echo "Succeed !"
-	else
-		echo "Failed !"
-	fi
 
 	return $ret
 }


### PR DESCRIPTION
In this PR, I define a standard method to parse the output files after the execution of the tests. The method parse all output files in full looking for any `failed` signal and if each cluster finished correctly. This enhancement prevents the architectures to fail because the last line was swapped with another that does not correspond to the previous accept state.