### PR TITLE
[mppa256] Bugfix: Spawning only clusters with one digit numerals

### DIFF
--- a/arch/mppa256.sh
+++ b/arch/mppa256.sh
@@ -148,7 +148,7 @@ function run
 	for cluster in `ls $imgdir | grep -o "[c-o]cluster[0-9]*[0-9]\."`;
 	do
 		type=`echo ${cluster: 0:1}`
-		number=`echo ${cluster: -2:1}`
+		number=`echo $cluster | grep -Eo "[0-9]{1,2}"`
 
 		if [ $type == "c" ]; then
 			execfile="$execfile \


### PR DESCRIPTION
In this PR, I fix a bug that I insert when introducing an enhancement to spawn builder on MPPA-256.

## Bug

The algorithm only works with numerals of one digit. When we try to run an image with more than 10 compute clusters will not spawn cluster on the range `[10, 15]`.

## Fix

I used `grep` to get the complete numeral from the cluster name.