### PR TITLE
[build] fix: apt python package superseeded by python3

### DIFF
--- a/nanvix-setup-prerequisites.sh
+++ b/nanvix-setup-prerequisites.sh
@@ -53,7 +53,7 @@ case "$DISTRO" in
 			libsdl2-dev      \
 			libtool          \
 			net-tools        \
-			python           \
+			python3          \
 			texinfo          \
 			uml-utilities    \
 			unzip            \


### PR DESCRIPTION
The name of the package changed from python to python3.
This commit fix a building error in Ubuntu 22.04